### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to S3 + CloudFront
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ervardaan/react-portfolio/security/code-scanning/1](https://github.com/ervardaan/react-portfolio/security/code-scanning/1)

To resolve this issue, add a `permissions` key at the top level of the workflow file (applies to all jobs that do not specify their own permissions). The key should at minimum include `contents: read` unless stronger permissions are known to be needed by jobs or steps (which is not indicated here). This limits the GITHUB_TOKEN to read-only access to repository contents, preventing unintended modifications. No existing functionality will be broken for typical deployment jobs that only read code and use external credentials for deployment. The `permissions` block should be inserted immediately below the `name` line or before `on` to conform to YAML structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
